### PR TITLE
Add authentication headers to the call getting filenames

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,12 +83,5 @@ if [[ `git status --porcelain` ]]; then
     if [ "COMMENTS_URL" != null ]; then
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
     fi
-else
-    COMMENT=":heavy_check_mark: That is a perfectly formatted change."
-    PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
-    COMMENTS_URL=$(cat /github/workflow/event.json | jq -r .pull_request.comments_url)
-    if [ "COMMENTS_URL" != null ]; then
-    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
-    fi
 fi
 exit $SUCCESS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ git fetch origin $BASE_BRANCH
 git fetch fork $HEAD_BRANCH
 
 URL="https://api.github.com/repos/${BASE_REPO}/pulls/${PR_NUMBER}/files"
-FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
+FILES=$(curl -s -X GET -H "${AUTH_HEADER}" -H "${API_HEADER}" -G $URL | jq -r '.[] | .filename')
 declare -i count=0
 declare -i ZERO=0
 


### PR DESCRIPTION
Without the authentication headers, the action is not able to fetch information from the API for private repositories.