### PR TITLE
Use go install instead of get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL "com.github.actions.icon"="git-pull-request"
 LABEL "com.github.actions.color"="blue"
 
 RUN apk --no-cache add jq bash curl git git-lfs
-RUN GO111MODULE=on go get mvdan.cc/gofumpt
+RUN GO111MODULE=on go install mvdan.cc/gofumpt
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
```sh
Step 11/14 : RUN GO111MODULE=on go get mvdan.cc/gofumpt
   ---> Running in 15d5cf0fb3a8
  go: go.mod file not found in current directory or any parent directory.
  	'go get' is no longer supported outside a module.
  	To build and install a command, use 'go install' with a version,
  	like 'go install example.com/cmd@latest'
  	For more information, see https://golang.org/doc/go-get-install-deprecation
  	or run 'go help get' or 'go help install'.
  The command '/bin/sh -c GO111MODULE=on go get mvdan.cc/gofumpt' returned a non-zero code: 1
```